### PR TITLE
Code refactoring for mac. Bugfix with openning ed2k links.

### DIFF
--- a/src/qmacapplication.cpp
+++ b/src/qmacapplication.cpp
@@ -40,19 +40,15 @@ QMacApplication::QMacApplication(QString appid, int &argc, char** argv) :
 }
 
 bool QMacApplication::event(QEvent * ev) {
-  switch (ev->type()) {
-  case QEvent::FileOpen:
-    {
-      QString path = static_cast<QFileOpenEvent *>(ev)->file();
-      if (path.isEmpty()) {
-        // Get the url instead
-		path = QUrl::fromPercentEncoding(file_event->url().toEncoded().data());
-      }
+  if (ev->type() == QEvent::FileOpen) {
+    QFileOpenEvent *file_event = static_cast<QFileOpenEvent *>(ev);
+    if (!file_event->url().isEmpty()) {
+      QString path = QUrl::fromPercentEncoding(file_event->url().toEncoded().data());
       qDebug("Received a mac file open event: %s", qPrintable(path));
       emit newFileOpenMacEvent(path);
       return true;
     }
-  default:
+  } else {
     return QtSingleApplication::event(ev);
   }
 }


### PR DESCRIPTION
- Исправление проблемы для мака. Протестировано для Safari.
- "Отрефакторен" код условия, так как надо проверять всего один тип события.
- Проверка именно на наличие url() вместо file() для QFileOpenEvent.

В прошлом исправлении не объявлена переменная file_event. Здесь она используется дважды после инициализации для оптимизации кода.
